### PR TITLE
Sunbird-Ed#349 - Cloud Storage SDK - OCI Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sunbird</groupId>
     <artifactId>cloud-store-sdk_2.12</artifactId>
-    <version>1.4.4</version>
+    <version>1.4.6</version>
     <packaging>jar</packaging>
     <name>Cloud Store SDK</name>
-    <description>cloud-store-sdk provides client APIs to handle cloud store (AWS S3, Azure Blobstore).</description>
+    <description>cloud-store-sdk provides client APIs to handle cloud store (AWS S3, Azure Blobstore, GCP, OCI).</description>
     <url>https://www.sunbird.org/</url>
     <properties>
     	<maven.compiler.source>1.7</maven.compiler.source>

--- a/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
@@ -48,4 +48,16 @@ object AppConf {
         else if (`type`.equals("oci")) getConfig("oci_storage_secret");
         else "";
     }
+
+    def getRegion(`type`: String): Option[String] = {
+        if (`type`.equals("oci"))
+            Option(getConfig("oci_region"))
+        else Option("");
+    }
+
+    def getEndPoint(`type`: String): Option[String] = {
+        if (`type`.equals("oci"))
+            Option(getConfig("oci_storage_endpoint"))
+        else None
+    }
 }

--- a/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
@@ -15,49 +15,24 @@ object AppConf {
         else "";
     }
 
-    def getConfig(): Config = {
-        return conf;
-    }
+    def getConfig: Config = conf
 
-    def getAwsKey(): String = {
-        getConfig("aws_storage_key");
-    }
 
-    def getAwsSecret(): String = {
-        getConfig("aws_storage_secret");
-    }
+    def getStorageType: String = getConfig("cloud_storage_type")
 
-    def getStorageType(): String = {
-        getConfig("cloud_storage_type");
-    }
+    def getStorageKey: String = getConfig("cloud_storage_key")
 
-    def getStorageKey(`type`: String): String = {
-        if (`type`.equals("aws")) getConfig("aws_storage_key");
-        else if (`type`.equals("azure")) getConfig("azure_storage_key");
-        else if (`type`.equals("cephs3")) getConfig("cephs3_storage_key");
-        else if (`type`.equals("gcloud")) getConfig("gcloud_client_key");
-        else if (`type`.equals("oci")) getConfig("oci_storage_key");
-        else "";
-    }
+    def getStorageSecret: String = getConfig("cloud_storage_secret")
 
-    def getStorageSecret(`type`: String): String = {
-        if (`type`.equals("aws")) getConfig("aws_storage_secret");
-        else if (`type`.equals("azure")) getConfig("azure_storage_secret");
-        else if (`type`.equals("cephs3")) getConfig("cephs3_storage_secret");
-        else if (`type`.equals("gcloud")) getConfig("gcloud_private_secret");
-        else if (`type`.equals("oci")) getConfig("oci_storage_secret");
-        else "";
-    }
-
-    def getRegion(`type`: String): Option[String] = {
-        if (`type`.equals("oci"))
-            Option(getConfig("oci_region"))
+    def getRegion: Option[String] = {
+        if (getStorageType.equals("oci"))
+            Option(getConfig("cloud_storage_region"))
         else Option("");
     }
 
-    def getEndPoint(`type`: String): Option[String] = {
-        if (`type`.equals("oci"))
-            Option(getConfig("oci_storage_endpoint"))
+    def getEndPoint: Option[String] = {
+        if (getStorageType.equals("oci"))
+            Option(getConfig("cloud_storage_endpoint"))
         else None
     }
 }

--- a/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
@@ -36,6 +36,7 @@ object AppConf {
         else if (`type`.equals("azure")) getConfig("azure_storage_key");
         else if (`type`.equals("cephs3")) getConfig("cephs3_storage_key");
         else if (`type`.equals("gcloud")) getConfig("gcloud_client_key");
+        else if (`type`.equals("oci")) getConfig("oci_storage_key");
         else "";
     }
 
@@ -44,6 +45,7 @@ object AppConf {
         else if (`type`.equals("azure")) getConfig("azure_storage_secret");
         else if (`type`.equals("cephs3")) getConfig("cephs3_storage_secret");
         else if (`type`.equals("gcloud")) getConfig("gcloud_private_secret");
+        else if (`type`.equals("oci")) getConfig("oci_storage_secret");
         else "";
     }
 }

--- a/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
@@ -27,12 +27,12 @@ object AppConf {
     def getRegion: Option[String] = {
         if (getStorageType.equals("oci"))
             Option(getConfig("cloud_storage_region"))
-        else Option("");
+        else Option("")
     }
 
     def getEndPoint: Option[String] = {
         if (getStorageType.equals("oci"))
             Option(getConfig("cloud_storage_endpoint"))
-        else None
+        else Option("")
     }
 }

--- a/src/main/scala/org/sunbird/cloud/storage/factory/StorageServiceFactory.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/factory/StorageServiceFactory.scala
@@ -2,7 +2,7 @@ package org.sunbird.cloud.storage.factory
 
 import org.sunbird.cloud.storage.BaseStorageService
 import org.sunbird.cloud.storage.exception.StorageServiceException
-import org.sunbird.cloud.storage.service.{AzureStorageService, S3StorageService, CephS3StorageService, GcloudStorageService}
+import org.sunbird.cloud.storage.service.{AzureStorageService, CephS3StorageService, GcloudStorageService, OCIS3StorageService, S3StorageService}
 
 case class StorageConfig(`type`: String, storageKey: String, storageSecret: String, endPoint: Option[String] = None)
 
@@ -23,6 +23,8 @@ object StorageServiceFactory {
                 new CephS3StorageService(config);
             case "gcloud"  =>
               new GcloudStorageService(config);
+            case "oci"  =>
+              new OCIS3StorageService(config);
             case _         =>
                 throw new StorageServiceException("Unknown storage type found");
         }

--- a/src/main/scala/org/sunbird/cloud/storage/factory/StorageServiceFactory.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/factory/StorageServiceFactory.scala
@@ -4,7 +4,7 @@ import org.sunbird.cloud.storage.BaseStorageService
 import org.sunbird.cloud.storage.exception.StorageServiceException
 import org.sunbird.cloud.storage.service.{AzureStorageService, CephS3StorageService, GcloudStorageService, OCIS3StorageService, S3StorageService}
 
-case class StorageConfig(`type`: String, storageKey: String, storageSecret: String, endPoint: Option[String] = None)
+case class StorageConfig(`type`: String, storageKey: String, storageSecret: String, endPoint: Option[String] = None, region: Option[String] = Option(""))
 
 object StorageServiceFactory {
 

--- a/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
@@ -1,13 +1,10 @@
 package org.sunbird.cloud.storage.service
 
-import com.google.common.collect.ImmutableSet
 import com.google.common.io.Files
 import com.google.common.hash
 import org.jclouds.ContextBuilder
-import org.jclouds.aws.s3.blobstore.config.AWSS3BlobStoreContextModule
 import org.jclouds.blobstore.BlobStoreContext
-import org.jclouds.s3.blobstore.config.S3BlobStoreContextModule
-import org.sunbird.cloud.storage.exception.StorageServiceException
+
 import org.sunbird.cloud.storage.{BaseStorageService, Model}
 import org.sunbird.cloud.storage.factory.StorageConfig
 
@@ -23,9 +20,10 @@ class OCIS3StorageService (config: StorageConfig) extends BaseStorageService {
   overrides.setProperty("jclouds.endpoint", config.endPoint.get)
   overrides.setProperty("jclouds.s3.virtual-host-buckets", "false")
   overrides.setProperty("jclouds.strip-expect-header", "true")
-  overrides.setProperty("jclouds.regions", "ap-hyderabad-1")
+  overrides.setProperty("jclouds.regions", config.region.get)
   overrides.setProperty("jclouds.s3.signer-version", "4")
 
+  println("Region:" + config.region.get)
   var context = ContextBuilder.newBuilder("aws-s3")
     .credentials(config.storageKey, config.storageSecret)
     .overrides(overrides)
@@ -45,81 +43,19 @@ class OCIS3StorageService (config: StorageConfig) extends BaseStorageService {
     objects.map{f => "s3n://" + container + "/" + f.key}
   }
 
-  override def upload(container: String, file: String, objectKey: String, isDirectory: Option[Boolean] = Option(false), attempt: Option[Int] = Option(1), retryCount: Option[Int] = None, ttl: Option[Int] = None): String = {
-    try {
-      if(isDirectory.get) {
-        val d = new File(file)
-        val files = filesList(d)
-        val list = files.map {f =>
-          val key = objectKey + f.getAbsolutePath.split(d.getAbsolutePath + File.separator).last
-          upload(container, f.getAbsolutePath, key, Option(false), attempt, retryCount, ttl)
-        }
-        list.mkString(",")
-      }
-      else {
-        if (attempt.getOrElse(1) >= retryCount.getOrElse(maxRetries)) {
-          val message = s"Failed to upload. file: $file, key: $objectKey, attempt: $attempt, maxAttempts: $retryCount. Exceeded maximum number of retries"
-          throw new StorageServiceException(message)
-        }
-
-
-        if (!( blobStore.containerExists(container) )) {
-          blobStore.createContainerInLocation(null, container)
-        }
-        val fileObj = new File(file)
-        val payload = Files.asByteSource(fileObj)
-        val payload_size  = payload.size()
-        val payload_md5 = payload.hash(hash.Hashing.md5())
-        val  contentType = tika.detect(fileObj)
-
-        val blob = blobStore.blobBuilder(objectKey).payload(payload).contentType(contentType).contentEncoding("UTF-8").contentLength(payload_size).contentMD5(payload_md5).build()
-        // blobStore.putBlob(container, blob, new PutOptions().multipart())
-        blobStore.putBlob(container, blob)
-        if (ttl.isDefined) {
-          getSignedURL(container, objectKey, Option(ttl.get))
-        } else
-          blobStore.blobMetadata(container, objectKey).getUri.toString
-      }
-    }
-    catch {
-      case e: Exception => {
-        e.printStackTrace()
-        Thread.sleep(attempt.getOrElse(1)*2000)
-        val uploadAttempt = attempt.getOrElse(1) + 1
-        if (uploadAttempt <= retryCount.getOrElse(maxRetries)) {
-          upload(container, file, objectKey, isDirectory, Option(uploadAttempt), retryCount, ttl)
-        } else {
-          throw e;
-        }
-      }
+  override def createContainerInLocation(container: String): Unit = {
+    if (!( blobStore.containerExists(container))) {
+      blobStore.createContainerInLocation(null, container)
     }
   }
 
-  override def put(container: String, content: Array[Byte], objectKey: String, isPublic: Option[Boolean] = Option(false), isDirectory: Option[Boolean] = Option(false), ttl: Option[Int] = None, retryCount: Option[Int] = None): String = {
-
-    try {
-
-      if (attempt == retryCount.getOrElse(maxRetries)) {
-        val message = s"Failed to upload. key: $objectKey, attempt: $attempt, maxAttempts: $retryCount. Exceeded maximum number of retries"
-        throw new StorageServiceException(message)
-      }
-
-      if (!( blobStore.containerExists(container) )) {
-        blobStore.createContainerInLocation(null, container)
-      }
-      val blob = blobStore.blobBuilder(objectKey).payload(content).contentLength(content.length).build()
-      blobStore.putBlob(container, blob)
-      if(isPublic.get) {
-        getSignedURL(container, objectKey, Option(ttl.getOrElse(maxSignedurlTTL)))
-      }
-      else blobStore.getBlob(container, objectKey).getMetadata.getUri.toString
-    }
-    catch {
-      case e: Exception => {
-        Thread.sleep(attempt*2000)
-        attempt += 1
-        put(container, content, objectKey, isPublic, isDirectory, ttl, retryCount)
-      }
-    }
+  override def putBlob(objectKey: String, file: File, container: String): Unit = {
+    val payload = Files.asByteSource(file)
+    val payloadSize  = payload.size()
+    val payloadMD5 = payload.hash(hash.Hashing.md5())
+    val  contentType = tika.detect(file)
+    val blob = blobStore.blobBuilder(objectKey).payload(payload).contentType(contentType).contentEncoding("UTF-8").contentLength(payloadSize).contentMD5(payloadMD5).build()
+    blobStore.putBlob(container, blob)
   }
+
 }

--- a/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
@@ -26,8 +26,6 @@ class OCIS3StorageService (config: StorageConfig) extends BaseStorageService {
   overrides.setProperty("jclouds.regions", "ap-hyderabad-1")
   overrides.setProperty("jclouds.s3.signer-version", "4")
 
-  val wiring = ImmutableSet.of(new S3BlobStoreContextModule());
-
   var context = ContextBuilder.newBuilder("aws-s3")
     .credentials(config.storageKey, config.storageSecret)
     .overrides(overrides)

--- a/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
@@ -1,0 +1,127 @@
+package org.sunbird.cloud.storage.service
+
+import com.google.common.collect.ImmutableSet
+import com.google.common.io.Files
+import com.google.common.hash
+import org.jclouds.ContextBuilder
+import org.jclouds.aws.s3.blobstore.config.AWSS3BlobStoreContextModule
+import org.jclouds.blobstore.BlobStoreContext
+import org.jclouds.s3.blobstore.config.S3BlobStoreContextModule
+import org.sunbird.cloud.storage.exception.StorageServiceException
+import org.sunbird.cloud.storage.{BaseStorageService, Model}
+import org.sunbird.cloud.storage.factory.StorageConfig
+
+import java.io.File
+import java.util.Properties
+
+class OCIS3StorageService (config: StorageConfig) extends BaseStorageService {
+
+
+  val overrides = new Properties()
+
+  overrides.setProperty("jclouds.provider", "s3")
+  overrides.setProperty("jclouds.endpoint", config.endPoint.get)
+  overrides.setProperty("jclouds.s3.virtual-host-buckets", "false")
+  overrides.setProperty("jclouds.strip-expect-header", "true")
+  overrides.setProperty("jclouds.regions", "ap-hyderabad-1")
+  overrides.setProperty("jclouds.s3.signer-version", "4")
+
+  val wiring = ImmutableSet.of(new S3BlobStoreContextModule());
+
+  var context = ContextBuilder.newBuilder("aws-s3")
+    .credentials(config.storageKey, config.storageSecret)
+    .overrides(overrides)
+    .endpoint(config.endPoint.get).buildView(classOf[BlobStoreContext])
+  var blobStore = context.getBlobStore
+  println("Signer: " + context.getSigner.toString)
+
+  /**
+   * Get HDFS compatible file paths to be used in tech stack like Spark.
+   * For ex: for S3 the file path is prefixed with s3n://<bucket>/<key> and for Azure blob storage it would be wasbs://<container-name>@<storage-account-name>.blob.core.windows.net/<key>/
+   *
+   * @param container String - The container/bucket of the objects
+   * @param objects   List[Blob] - The Blob objects in the given container
+   * @return List[String] - HDFS compatible file paths.
+   */
+  override def getPaths(container: String, objects: List[Model.Blob]): List[String] = {
+    objects.map{f => "s3n://" + container + "/" + f.key}
+  }
+
+  override def upload(container: String, file: String, objectKey: String, isDirectory: Option[Boolean] = Option(false), attempt: Option[Int] = Option(1), retryCount: Option[Int] = None, ttl: Option[Int] = None): String = {
+    try {
+      if(isDirectory.get) {
+        val d = new File(file)
+        val files = filesList(d)
+        val list = files.map {f =>
+          val key = objectKey + f.getAbsolutePath.split(d.getAbsolutePath + File.separator).last
+          upload(container, f.getAbsolutePath, key, Option(false), attempt, retryCount, ttl)
+        }
+        list.mkString(",")
+      }
+      else {
+        if (attempt.getOrElse(1) >= retryCount.getOrElse(maxRetries)) {
+          val message = s"Failed to upload. file: $file, key: $objectKey, attempt: $attempt, maxAttempts: $retryCount. Exceeded maximum number of retries"
+          throw new StorageServiceException(message)
+        }
+
+
+        if (!( blobStore.containerExists(container) )) {
+          blobStore.createContainerInLocation(null, container)
+        }
+        val fileObj = new File(file)
+        val payload = Files.asByteSource(fileObj)
+        val payload_size  = payload.size()
+        val payload_md5 = payload.hash(hash.Hashing.md5())
+        val  contentType = tika.detect(fileObj)
+
+        val blob = blobStore.blobBuilder(objectKey).payload(payload).contentType(contentType).contentEncoding("UTF-8").contentLength(payload_size).contentMD5(payload_md5).build()
+        // blobStore.putBlob(container, blob, new PutOptions().multipart())
+        blobStore.putBlob(container, blob)
+        if (ttl.isDefined) {
+          getSignedURL(container, objectKey, Option(ttl.get))
+        } else
+          blobStore.blobMetadata(container, objectKey).getUri.toString
+      }
+    }
+    catch {
+      case e: Exception => {
+        e.printStackTrace()
+        Thread.sleep(attempt.getOrElse(1)*2000)
+        val uploadAttempt = attempt.getOrElse(1) + 1
+        if (uploadAttempt <= retryCount.getOrElse(maxRetries)) {
+          upload(container, file, objectKey, isDirectory, Option(uploadAttempt), retryCount, ttl)
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  override def put(container: String, content: Array[Byte], objectKey: String, isPublic: Option[Boolean] = Option(false), isDirectory: Option[Boolean] = Option(false), ttl: Option[Int] = None, retryCount: Option[Int] = None): String = {
+
+    try {
+
+      if (attempt == retryCount.getOrElse(maxRetries)) {
+        val message = s"Failed to upload. key: $objectKey, attempt: $attempt, maxAttempts: $retryCount. Exceeded maximum number of retries"
+        throw new StorageServiceException(message)
+      }
+
+      if (!( blobStore.containerExists(container) )) {
+        blobStore.createContainerInLocation(null, container)
+      }
+      val blob = blobStore.blobBuilder(objectKey).payload(content).contentLength(content.length).build()
+      blobStore.putBlob(container, blob)
+      if(isPublic.get) {
+        getSignedURL(container, objectKey, Option(ttl.getOrElse(maxSignedurlTTL)))
+      }
+      else blobStore.getBlob(container, objectKey).getMetadata.getUri.toString
+    }
+    catch {
+      case e: Exception => {
+        Thread.sleep(attempt*2000)
+        attempt += 1
+        put(container, content, objectKey, isPublic, isDirectory, ttl, retryCount)
+      }
+    }
+  }
+}

--- a/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
@@ -23,13 +23,11 @@ class OCIS3StorageService (config: StorageConfig) extends BaseStorageService {
   overrides.setProperty("jclouds.regions", config.region.get)
   overrides.setProperty("jclouds.s3.signer-version", "4")
 
-  println("Region:" + config.region.get)
   var context = ContextBuilder.newBuilder("aws-s3")
     .credentials(config.storageKey, config.storageSecret)
     .overrides(overrides)
     .endpoint(config.endPoint.get).buildView(classOf[BlobStoreContext])
   var blobStore = context.getBlobStore
-  println("Signer: " + context.getSigner.toString)
 
   /**
    * Get HDFS compatible file paths to be used in tech stack like Spark.

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,15 +1,16 @@
 local_extract_path="/tmp/extract/"
-#azure_storage_container="test-container"
-#gcloud_storage_container="test-obsrv-data-store"
-
 cloud_storage_type="aws"
+
 # AWS S3 Configuration
-aws_storage_container="sunbird-dev-data-store"
+aws_storage_container="ekstep-dev-data-store"
 aws_storage_key=""
 aws_storage_secret=""
 
 # Azure configuration
-azure_storage_container="sunbird-test-container"
+azure_storage_container="test-container"
+
+#Gcloud configuration
+gcloud_storage_container="test-obsrv-data-store"
 
 # OCI Configuration
 oci_storage_container=""

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -18,4 +18,4 @@ oci_storage_key=""
 oci_storage_secret=""
 oci_region="ap-hyderabad-1"
 # sample endpoint url: https://<bucket-namespace>.compat.objectstorage.<region>.oraclecloud.com
-oci_storage_endpoint=""
+oci_storage_endpoint="https://xyz.compat.objectstorage.ap-hyderabad-1.oraclecloud.com"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,5 +1,20 @@
 local_extract_path="/tmp/extract/"
-cloud_storage_type="azure"
-aws_storage_container="ekstep-dev-data-store"
-azure_storage_container="test-container"
-gcloud_storage_container="test-obsrv-data-store"
+#azure_storage_container="test-container"
+#gcloud_storage_container="test-obsrv-data-store"
+
+cloud_storage_type="aws"
+# AWS S3 Configuration
+aws_storage_container="sunbird-dev-data-store"
+aws_storage_key=""
+aws_storage_secret=""
+
+# Azure configuration
+azure_storage_container="sunbird-test-container"
+
+# OCI Configuration
+oci_storage_container=""
+oci_storage_key=""
+oci_storage_secret=""
+oci_region="ap-hyderabad-1"
+# sample endpoint url: https://<bucket-namespace>.compat.objectstorage.<region>.oraclecloud.com
+oci_storage_endpoint=""

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestAzureStorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestAzureStorageService.scala
@@ -10,9 +10,9 @@ class TestAzureStorageService extends FlatSpec with Matchers {
 
     it should "test for azure storage" in {
 
-        val azureService = StorageServiceFactory.getStorageService(StorageConfig("azure", AppConf.getStorageKey("azure"), AppConf.getStorageSecret("azure")))
+        val azureService = StorageServiceFactory.getStorageService(StorageConfig("azure", AppConf.getStorageKey, AppConf.getStorageSecret))
 
-        val storageContainer = AppConf.getConfig("azure_storage_container")
+        val storageContainer = AppConf.getConfig("cloud_storage_container")
 
         azureService.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log", Option(false), Option(1), Option(2), None)
        // azureService.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-azure/")

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestGcloudStorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestGcloudStorageService.scala
@@ -9,9 +9,9 @@ class TestGcloudStorageService extends FlatSpec with Matchers {
 
   it should "test for gcloud storage" in {
 
-    val gsService = StorageServiceFactory.getStorageService(StorageConfig("gcloud", AppConf.getStorageKey("gcloud"), AppConf.getStorageSecret("gcloud")))
+    val gsService = StorageServiceFactory.getStorageService(StorageConfig("gcloud", AppConf.getStorageKey, AppConf.getStorageSecret))
 
-    val storageContainer = AppConf.getConfig("gcloud_storage_container")
+    val storageContainer = AppConf.getConfig("cloud_storage_container")
 
 //    gsService.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log", Option(false), Option(1), Option(2), None)
 //    gsService.upload(storageContainer, "src/test/resources/test-extract.zip", "testUpload/test-extract.zip", Option(false), Option(1), Option(2), None)

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -15,7 +15,7 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
     val storageContainer = AppConf.getConfig("oci_storage_container")
 
     // Use this exception block to execute the test cases successfully when it has invalid configuration.
-    println(ociS3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
+    println(ociS3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false)))
     val caught =
         intercept[StorageServiceException]{
           ociS3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
@@ -26,6 +26,7 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
      * Use the below complete block when we have the valid configuration and
      * to test the OCI functionality.
      */
+    /**
     ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
     ociS3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
 
@@ -60,6 +61,8 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
     ociS3Service.copyObjects(storageContainer, "testUpload/test-extract.zip", storageContainer, "testDuplicate/test-extract.zip")
 
     ociS3Service.extractArchive(storageContainer, "testUpload/test-extract.zip", "testUpload/test-extract/")
+    */
+    ociS3Service.closeContext()
   }
 
 }

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -1,0 +1,56 @@
+package org.sunbird.cloud.storage.service
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.sunbird.cloud.storage.conf.AppConf
+import org.sunbird.cloud.storage.factory.{StorageConfig, StorageServiceFactory}
+
+class TestOCIS3StorageService  extends FlatSpec with Matchers {
+
+  it should "test for OCIS3 storage" in {
+
+    val ociS3Service = StorageServiceFactory.getStorageService(StorageConfig("oci", AppConf.getStorageKey("oci"), AppConf.getStorageSecret("oci"), Option("https://ax2cel5zyviy.compat.objectstorage.ap-hyderabad-1.oraclecloud.com")))
+
+    val storageContainer = AppConf.getConfig("oci_storage_container")
+    println("Key : " + AppConf.getStorageKey("oci"))
+    println("Secret : " + AppConf.getStorageSecret("oci"))
+    println("Storage: " + storageContainer)
+
+    ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
+    ociS3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
+
+    // upload directory
+    println("url of folder", ociS3Service.upload(storageContainer, "src/test/resources/1234/", "testUpload/1234/", Option(true)))
+
+    // downlaod directory
+    ociS3Service.download(storageContainer, "testUpload/1234/", "src/test/resources/test-s3/", Option(true))
+
+    println("OCIS3 signed url", ociS3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
+
+    val blob = ociS3Service.getObject(storageContainer, "testUpload/test-blob.log")
+    println("blob details: ", blob)
+
+    println("upload public url", ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-public.log", Option(true)))
+    println("upload public with expiry url", ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-with-expiry.log", Option(false)))
+    println("signed path to upload from external client", ociS3Service.getSignedURL(storageContainer, "testUpload/test-data-public1.log", Option(600), Option("w")))
+
+    val keys = ociS3Service.searchObjectkeys(storageContainer, "testUpload/1234/")
+    keys.foreach(f => println(f))
+    val blobs = ociS3Service.searchObjects(storageContainer, "testUpload/1234/")
+    blobs.foreach(f => println(f))
+
+    val objData = ociS3Service.getObjectData(storageContainer, "testUpload/test-blob.log")
+    objData.length should be(18)
+
+    // delete directory
+    ociS3Service.deleteObject(storageContainer, "testUpload/1234/", Option(true))
+    ociS3Service.deleteObject(storageContainer, "testUpload/test-blob.log")
+
+    ociS3Service.upload(storageContainer, "src/test/resources/test-extract.zip", "testUpload/test-extract.zip")
+    ociS3Service.copyObjects(storageContainer, "testUpload/test-extract.zip", storageContainer, "testDuplicate/test-extract.zip")
+
+    ociS3Service.extractArchive(storageContainer, "testUpload/test-extract.zip", "testUpload/test-extract/")
+
+
+  }
+
+}

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -8,7 +8,8 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
 
   it should "test for OCIS3 storage" in {
 
-    val ociS3Service = StorageServiceFactory.getStorageService(StorageConfig("oci", AppConf.getStorageKey("oci"), AppConf.getStorageSecret("oci"), Option("https://ax2cel5zyviy.compat.objectstorage.ap-hyderabad-1.oraclecloud.com")))
+    val storageConfig = StorageConfig("oci", AppConf.getStorageKey("oci"), AppConf.getStorageSecret("oci"), AppConf.getEndPoint("oci"), AppConf.getRegion("oci"))
+    val ociS3Service = StorageServiceFactory.getStorageService(storageConfig)
 
     val storageContainer = AppConf.getConfig("oci_storage_container")
     println("Key : " + AppConf.getStorageKey("oci"))

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -12,9 +12,6 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
     val ociS3Service = StorageServiceFactory.getStorageService(storageConfig)
 
     val storageContainer = AppConf.getConfig("oci_storage_container")
-    println("Key : " + AppConf.getStorageKey("oci"))
-    println("Secret : " + AppConf.getStorageSecret("oci"))
-    println("Storage: " + storageContainer)
 
     ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
     ociS3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
@@ -50,8 +47,6 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
     ociS3Service.copyObjects(storageContainer, "testUpload/test-extract.zip", storageContainer, "testDuplicate/test-extract.zip")
 
     ociS3Service.extractArchive(storageContainer, "testUpload/test-extract.zip", "testUpload/test-extract/")
-
-
   }
 
 }

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -15,7 +15,6 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
     val storageContainer = AppConf.getConfig("oci_storage_container")
 
     // Use this exception block to execute the test cases successfully when it has invalid configuration.
-    println(ociS3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false)))
     val caught =
         intercept[StorageServiceException]{
           ociS3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -9,10 +9,10 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
 
   it should "test for OCIS3 storage" in {
 
-    val storageConfig = StorageConfig("oci", AppConf.getStorageKey("oci"), AppConf.getStorageSecret("oci"), AppConf.getEndPoint("oci"), AppConf.getRegion("oci"))
+    val storageConfig = StorageConfig("oci", AppConf.getStorageKey, AppConf.getStorageSecret, AppConf.getEndPoint, AppConf.getRegion)
     val ociS3Service = StorageServiceFactory.getStorageService(storageConfig)
 
-    val storageContainer = AppConf.getConfig("oci_storage_container")
+    val storageContainer = AppConf.getConfig("cloud_storage_container")
 
     // Use this exception block to execute the test cases successfully when it has invalid configuration.
     val caught =

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -9,7 +9,7 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
 
   it should "test for OCIS3 storage" in {
 
-    val storageConfig = StorageConfig("oci", AppConf.getStorageKey, AppConf.getStorageSecret, AppConf.getEndPoint, AppConf.getRegion)
+    val storageConfig = StorageConfig("oci", AppConf.getStorageKey, AppConf.getStorageSecret, Option("https://xyz.compat.objectstorage.ap-hyderabad-1.oraclecloud.com"), AppConf.getRegion)
     val ociS3Service = StorageServiceFactory.getStorageService(storageConfig)
 
     val storageContainer = AppConf.getConfig("cloud_storage_container")

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -2,6 +2,7 @@ package org.sunbird.cloud.storage.service
 
 import org.scalatest.{FlatSpec, Matchers}
 import org.sunbird.cloud.storage.conf.AppConf
+import org.sunbird.cloud.storage.exception.StorageServiceException
 import org.sunbird.cloud.storage.factory.{StorageConfig, StorageServiceFactory}
 
 class TestOCIS3StorageService  extends FlatSpec with Matchers {
@@ -13,6 +14,18 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
 
     val storageContainer = AppConf.getConfig("oci_storage_container")
 
+    // Use this exception block to execute the test cases successfully when it has invalid configuration.
+    println(ociS3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
+    val caught =
+        intercept[StorageServiceException]{
+          ociS3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
+        }
+    assert(caught.getMessage.contains("Failed to upload."))
+
+    /**
+     * Use the below complete block when we have the valid configuration and
+     * to test the OCI functionality.
+     */
     ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
     ociS3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
 
@@ -22,7 +35,7 @@ class TestOCIS3StorageService  extends FlatSpec with Matchers {
     // downlaod directory
     ociS3Service.download(storageContainer, "testUpload/1234/", "src/test/resources/test-s3/", Option(true))
 
-    println("OCIS3 signed url", ociS3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
+    println("OCI S3 signed url", ociS3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
 
     val blob = ociS3Service.getObject(storageContainer, "testUpload/test-blob.log")
     println("blob details: ", blob)

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
@@ -10,9 +10,9 @@ class TestS3StorageService extends FlatSpec with Matchers {
 
     it should "test for s3 storage" in {
 
-        val s3Service = StorageServiceFactory.getStorageService(StorageConfig("aws", AppConf.getStorageKey("aws"), AppConf.getStorageSecret("aws")))
+        val s3Service = StorageServiceFactory.getStorageService(StorageConfig("aws", AppConf.getStorageKey, AppConf.getStorageSecret))
 
-        val storageContainer = AppConf.getConfig("aws_storage_container")
+        val storageContainer = AppConf.getConfig("cloud_storage_container")
 
         //println(s3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
         val caught =

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
@@ -13,30 +13,35 @@ class TestS3StorageService extends FlatSpec with Matchers {
         val s3Service = StorageServiceFactory.getStorageService(StorageConfig("aws", AppConf.getStorageKey("aws"), AppConf.getStorageSecret("aws")))
 
         val storageContainer = AppConf.getConfig("aws_storage_container")
+        println("Key : "+ AppConf.getStorageKey("aws"))
+        println("Secret : "+ AppConf.getStorageSecret("aws"))
+        println("Storage: " + storageContainer)
 
-        //println(s3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
-        val caught =
-            intercept[StorageServiceException]{
-                s3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
-            }
-        assert(caught.getMessage.contains("Failed to upload."))
-        /*
+//        println(s3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
+//        val caught =
+//            intercept[StorageServiceException]{
+//                s3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
+//            }
+//        assert(caught.getMessage.contains("Failed to upload."))
+
         s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
         s3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
 
         // upload directory
-        println("url of folder", s3Service.upload(storageContainer, "src/test/resources/1234/", "testUpload/1234/", None, Option(true)))
+        println("url of folder", s3Service.upload(storageContainer, "src/test/resources/1234/", "testUpload/1234/", Option(true)))
 
         // downlaod directory
         s3Service.download(storageContainer, "testUpload/1234/", "src/test/resources/test-s3/", Option(true))
 
-        println("azure signed url", s3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
+
+        println("aws signed url", s3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
 
         val blob = s3Service.getObject(storageContainer, "testUpload/test-blob.log")
         println("blob details: ", blob)
 
+
         println("upload public url", s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-public.log", Option(true)))
-        println("upload public with expiry url", s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-with-expiry.log", Option(true), Option(false), Option(600)))
+        println("upload public with expiry url", s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-with-expiry.log", Option(false)))
         println("signed path to upload from external client", s3Service.getSignedURL(storageContainer, "testUpload/test-data-public1.log", Option(600), Option("w")))
 
         val keys = s3Service.searchObjectkeys(storageContainer, "testUpload/1234/")
@@ -57,7 +62,7 @@ class TestS3StorageService extends FlatSpec with Matchers {
         s3Service.copyObjects(storageContainer, "testUpload/test-extract.zip", storageContainer, "testDuplicate/test-extract.zip")
 
         s3Service.extractArchive(storageContainer, "testUpload/test-extract.zip", "testUpload/test-extract/")
-        */
+
 
         // Test if the listObjectKeys lists all objects inside a directory when the number of objects count
         // is greater than threshold value 1000

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
@@ -13,9 +13,6 @@ class TestS3StorageService extends FlatSpec with Matchers {
         val s3Service = StorageServiceFactory.getStorageService(StorageConfig("aws", AppConf.getStorageKey("aws"), AppConf.getStorageSecret("aws")))
 
         val storageContainer = AppConf.getConfig("aws_storage_container")
-        println("Key : "+ AppConf.getStorageKey("aws"))
-        println("Secret : "+ AppConf.getStorageSecret("aws"))
-        println("Storage: " + storageContainer)
 
 //        println(s3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
 //        val caught =

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestS3StorageService.scala
@@ -14,66 +14,52 @@ class TestS3StorageService extends FlatSpec with Matchers {
 
         val storageContainer = AppConf.getConfig("aws_storage_container")
 
-//        println(s3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
-//        val caught =
-//            intercept[StorageServiceException]{
-//                s3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
-//            }
-//        assert(caught.getMessage.contains("Failed to upload."))
-
+        //println(s3Service.upload(storageContainer, "src/test/resources/110Mb_File.zip", "testUpload/110Mb_File.zip", Option(false),Option(false),None, Option(3), 1))
+        val caught =
+            intercept[StorageServiceException]{
+                s3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
+            }
+        assert(caught.getMessage.contains("Failed to upload."))
+        /*
         s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
         s3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
-
         // upload directory
-        println("url of folder", s3Service.upload(storageContainer, "src/test/resources/1234/", "testUpload/1234/", Option(true)))
-
+        println("url of folder", s3Service.upload(storageContainer, "src/test/resources/1234/", "testUpload/1234/", None, Option(true)))
         // downlaod directory
         s3Service.download(storageContainer, "testUpload/1234/", "src/test/resources/test-s3/", Option(true))
-
-
         println("aws signed url", s3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
-
         val blob = s3Service.getObject(storageContainer, "testUpload/test-blob.log")
         println("blob details: ", blob)
-
-
         println("upload public url", s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-public.log", Option(true)))
-        println("upload public with expiry url", s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-with-expiry.log", Option(false)))
+        println("upload public with expiry url", s3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-with-expiry.log", Option(true), Option(false), Option(600)))
         println("signed path to upload from external client", s3Service.getSignedURL(storageContainer, "testUpload/test-data-public1.log", Option(600), Option("w")))
-
         val keys = s3Service.searchObjectkeys(storageContainer, "testUpload/1234/")
         keys.foreach(f => println(f))
         val blobs = s3Service.searchObjects(storageContainer, "testUpload/1234/")
         blobs.foreach(f => println(f))
-
         val objData = s3Service.getObjectData(storageContainer, "testUpload/test-blob.log")
         objData.length should be(18)
-
         // delete directory
         s3Service.deleteObject(storageContainer, "testUpload/1234/", Option(true))
         s3Service.deleteObject(storageContainer, "testUpload/test-blob.log")
         //s3Service.deleteObject(storageContainer, "testUpload/test-data-public.log")
         //s3Service.deleteObject(storageContainer, "testUpload/test-data-with-expiry.log")
-
         s3Service.upload(storageContainer, "src/test/resources/test-extract.zip", "testUpload/test-extract.zip")
         s3Service.copyObjects(storageContainer, "testUpload/test-extract.zip", storageContainer, "testDuplicate/test-extract.zip")
-
         s3Service.extractArchive(storageContainer, "testUpload/test-extract.zip", "testUpload/test-extract/")
-
+        */
 
         // Test if the listObjectKeys lists all objects inside a directory when the number of objects count
         // is greater than threshold value 1000
-       /* val objectsListInsideADirectory = s3Service.listObjectKeys("ekstep-public-dev", _prefix = "content/h5p/do_112620111166709760183-snapshot/content")
-        objectsListInsideADirectory.size should be (1200)
-
-        // Test if the listObjectKeys lists individual files if the prefix is not a directory
-        val fileObject = s3Service.listObjectKeys("ekstep-public-dev", _prefix = "content/h5p/do_112620111166709760183-snapshot/index.html")
-        fileObject.size should be (1)
-        fileObject.head should be ("content/h5p/do_112620111166709760183-snapshot/index.html")
-
-        // Test if the listObjectKeys lists no files if the filename is not found
-        val noFilesFound = s3Service.listObjectKeys("ekstep-public-dev", _prefix = "random_file_name_which_is_not_present")
-        noFilesFound.size should be (0)*/
+        /* val objectsListInsideADirectory = s3Service.listObjectKeys("ekstep-public-dev", _prefix = "content/h5p/do_112620111166709760183-snapshot/content")
+         objectsListInsideADirectory.size should be (1200)
+         // Test if the listObjectKeys lists individual files if the prefix is not a directory
+         val fileObject = s3Service.listObjectKeys("ekstep-public-dev", _prefix = "content/h5p/do_112620111166709760183-snapshot/index.html")
+         fileObject.size should be (1)
+         fileObject.head should be ("content/h5p/do_112620111166709760183-snapshot/index.html")
+         // Test if the listObjectKeys lists no files if the filename is not found
+         val noFilesFound = s3Service.listObjectKeys("ekstep-public-dev", _prefix = "random_file_name_which_is_not_present")
+         noFilesFound.size should be (0)*/
 
         s3Service.closeContext()
     }


### PR DESCRIPTION
Oracle Cloud Infrastructure has S3 compliant object storage. The current version of `cloud-storage-sdk` doesn't have implementation for OCI.

This PR has the changes to support OCI. The configuration to enable OCI is below:

```yaml
# OCI Configuration
oci_storage_container=""
oci_storage_key=""
oci_storage_secret=""
oci_region=""
# sample endpoint url: https://<bucket-namespace>.compat.objectstorage.<region>.oraclecloud.com
oci_storage_endpoint=""

```
Sunbird-Ed Discussion: [Sunbird-Ed#349](https://github.com/Sunbird-Ed/Community/discussions/349)
