### PR TITLE
Sunbird-Ed#349 - Cloud Storage SDK - OCI Support with Scala 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sunbird</groupId>
     <artifactId>cloud-store-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.4.6</version>
     <packaging>jar</packaging>
     <name>Cloud Store SDK</name>
-    <description>cloud-store-sdk provides client APIs to handle cloud store (AWS S3, Azure Blobstore).</description>
+    <description>cloud-store-sdk provides client APIs to handle cloud store (AWS S3, Azure Blobstore, GCP, OCI).</description>
     <url>https://www.sunbird.org/</url>
     <properties>
     	<maven.compiler.source>1.7</maven.compiler.source>

--- a/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/conf/AppConf.scala
@@ -35,6 +35,7 @@ object AppConf {
         if (`type`.equals("aws")) getConfig("aws_storage_key");
         else if (`type`.equals("azure")) getConfig("azure_storage_key");
         else if (`type`.equals("gcloud")) getConfig("gcloud_client_key");
+        else if (`type`.equals("oci")) getConfig("oci_storage_key");
         else "";
     }
 
@@ -42,6 +43,19 @@ object AppConf {
         if (`type`.equals("aws")) getConfig("aws_storage_secret");
         else if (`type`.equals("azure")) getConfig("azure_storage_secret");
         else if (`type`.equals("gcloud")) getConfig("gcloud_private_secret");
+        else if (`type`.equals("oci")) getConfig("oci_storage_secret");
         else "";
+    }
+
+    def getRegion(`type`: String): Option[String] = {
+        if (`type`.equals("oci"))
+            Option(getConfig("oci_region"))
+        else Option("");
+    }
+
+    def getEndPoint(`type`: String): Option[String] = {
+        if (`type`.equals("oci"))
+            Option(getConfig("oci_storage_endpoint"))
+        else None
     }
 }

--- a/src/main/scala/org/sunbird/cloud/storage/factory/StorageServiceFactory.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/factory/StorageServiceFactory.scala
@@ -2,9 +2,9 @@ package org.sunbird.cloud.storage.factory
 
 import org.sunbird.cloud.storage.BaseStorageService
 import org.sunbird.cloud.storage.exception.StorageServiceException
-import org.sunbird.cloud.storage.service.{AzureStorageService, S3StorageService, GcloudStorageService}
+import org.sunbird.cloud.storage.service.{AzureStorageService, GcloudStorageService, OCIS3StorageService, S3StorageService}
 
-case class StorageConfig(`type`: String, storageKey: String, storageSecret: String)
+case class StorageConfig(`type`: String, storageKey: String, storageSecret: String, endPoint: Option[String] = None, region: Option[String] = Option(""))
 
 object StorageServiceFactory {
 
@@ -21,6 +21,8 @@ object StorageServiceFactory {
                 new AzureStorageService(config);
             case "gcloud"  =>
               new GcloudStorageService(config);
+            case "oci"  =>
+              new OCIS3StorageService(config);
             case _         =>
                 throw new StorageServiceException("Unknown storage type found");
         }

--- a/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
+++ b/src/main/scala/org/sunbird/cloud/storage/service/OCIS3StorageService.scala
@@ -1,0 +1,59 @@
+package org.sunbird.cloud.storage.service
+
+import com.google.common.io.Files
+import com.google.common.hash
+import org.jclouds.ContextBuilder
+import org.jclouds.blobstore.BlobStoreContext
+
+import org.sunbird.cloud.storage.{BaseStorageService, Model}
+import org.sunbird.cloud.storage.factory.StorageConfig
+
+import java.io.File
+import java.util.Properties
+
+class OCIS3StorageService (config: StorageConfig) extends BaseStorageService {
+
+
+  val overrides = new Properties()
+
+  overrides.setProperty("jclouds.provider", "s3")
+  overrides.setProperty("jclouds.endpoint", config.endPoint.get)
+  overrides.setProperty("jclouds.s3.virtual-host-buckets", "false")
+  overrides.setProperty("jclouds.strip-expect-header", "true")
+  overrides.setProperty("jclouds.regions", config.region.get)
+  overrides.setProperty("jclouds.s3.signer-version", "4")
+
+  var context = ContextBuilder.newBuilder("aws-s3")
+    .credentials(config.storageKey, config.storageSecret)
+    .overrides(overrides)
+    .endpoint(config.endPoint.get).buildView(classOf[BlobStoreContext])
+  var blobStore = context.getBlobStore
+
+  /**
+   * Get HDFS compatible file paths to be used in tech stack like Spark.
+   * For ex: for S3 the file path is prefixed with s3n://<bucket>/<key> and for Azure blob storage it would be wasbs://<container-name>@<storage-account-name>.blob.core.windows.net/<key>/
+   *
+   * @param container String - The container/bucket of the objects
+   * @param objects   List[Blob] - The Blob objects in the given container
+   * @return List[String] - HDFS compatible file paths.
+   */
+  override def getPaths(container: String, objects: List[Model.Blob]): List[String] = {
+    objects.map{f => "s3n://" + container + "/" + f.key}
+  }
+
+  override def createContainerInLocation(container: String): Unit = {
+    if (!( blobStore.containerExists(container))) {
+      blobStore.createContainerInLocation(null, container)
+    }
+  }
+
+  override def putBlob(objectKey: String, file: File, container: String): Unit = {
+    val payload = Files.asByteSource(file)
+    val payloadSize  = payload.size()
+    val payloadMD5 = payload.hash(hash.Hashing.md5())
+    val  contentType = tika.detect(file)
+    val blob = blobStore.blobBuilder(objectKey).payload(payload).contentType(contentType).contentEncoding("UTF-8").contentLength(payloadSize).contentMD5(payloadMD5).build()
+    blobStore.putBlob(container, blob)
+  }
+
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,5 +1,21 @@
 local_extract_path="/tmp/extract/"
-cloud_storage_type="azure"
+cloud_storage_type="aws"
+
+# AWS S3 Configuration
 aws_storage_container="ekstep-dev-data-store"
+aws_storage_key=""
+aws_storage_secret=""
+
+# Azure configuration
 azure_storage_container="test-container"
+
+#Gcloud configuration
 gcloud_storage_container="test-obsrv-data-store"
+
+# OCI Configuration
+oci_storage_container=""
+oci_storage_key=""
+oci_storage_secret=""
+oci_region="ap-hyderabad-1"
+# sample endpoint url: https://<bucket-namespace>.compat.objectstorage.<region>.oraclecloud.com
+oci_storage_endpoint="https://xyz.compat.objectstorage.ap-hyderabad-1.oraclecloud.com"

--- a/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
+++ b/src/test/scala/org/sunbird/cloud/storage/service/TestOCIS3StorageService.scala
@@ -1,0 +1,57 @@
+package org.sunbird.cloud.storage.service
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.sunbird.cloud.storage.conf.AppConf
+import org.sunbird.cloud.storage.exception.StorageServiceException
+import org.sunbird.cloud.storage.factory.{StorageConfig, StorageServiceFactory}
+
+class TestOCIS3StorageService  extends FlatSpec with Matchers {
+
+  it should "test for OCIS3 storage" in {
+
+    val storageConfig = StorageConfig("oci", AppConf.getStorageKey("oci"), AppConf.getStorageSecret("oci"), AppConf.getEndPoint("oci"), AppConf.getRegion("oci"))
+    val ociS3Service = StorageServiceFactory.getStorageService(storageConfig)
+
+    val storageContainer = AppConf.getConfig("oci_storage_container")
+
+    // Use this exception block to execute the test cases successfully when it has invalid configuration.
+    val caught =
+      intercept[StorageServiceException]{
+        ociS3Service.upload(storageContainer, "src/test/resources/1234/test-blob.log", "testUpload/1234/", Option(false),Option(5), Option(2), None)
+      }
+    assert(caught.getMessage.contains("Failed to upload."))
+
+    /**
+     * Use the below complete block when we have the valid configuration and
+     * to test the OCI functionality.
+     */
+    /**
+    ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-blob.log")
+    ociS3Service.download(storageContainer, "testUpload/test-blob.log", "src/test/resources/test-s3/")
+    // upload directory
+    println("url of folder", ociS3Service.upload(storageContainer, "src/test/resources/1234/", "testUpload/1234/", Option(true)))
+    // downlaod directory
+    ociS3Service.download(storageContainer, "testUpload/1234/", "src/test/resources/test-s3/", Option(true))
+    println("OCI S3 signed url", ociS3Service.getSignedURL(storageContainer, "testUpload/test-blob.log", Option(600)))
+    val blob = ociS3Service.getObject(storageContainer, "testUpload/test-blob.log")
+    println("blob details: ", blob)
+    println("upload public url", ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-public.log", Option(true)))
+    println("upload public with expiry url", ociS3Service.upload(storageContainer, "src/test/resources/test-data.log", "testUpload/test-data-with-expiry.log", Option(false)))
+    println("signed path to upload from external client", ociS3Service.getSignedURL(storageContainer, "testUpload/test-data-public1.log", Option(600), Option("w")))
+    val keys = ociS3Service.searchObjectkeys(storageContainer, "testUpload/1234/")
+    keys.foreach(f => println(f))
+    val blobs = ociS3Service.searchObjects(storageContainer, "testUpload/1234/")
+    blobs.foreach(f => println(f))
+    val objData = ociS3Service.getObjectData(storageContainer, "testUpload/test-blob.log")
+    objData.length should be(18)
+    // delete directory
+    ociS3Service.deleteObject(storageContainer, "testUpload/1234/", Option(true))
+    ociS3Service.deleteObject(storageContainer, "testUpload/test-blob.log")
+    ociS3Service.upload(storageContainer, "src/test/resources/test-extract.zip", "testUpload/test-extract.zip")
+    ociS3Service.copyObjects(storageContainer, "testUpload/test-extract.zip", storageContainer, "testDuplicate/test-extract.zip")
+    ociS3Service.extractArchive(storageContainer, "testUpload/test-extract.zip", "testUpload/test-extract/")
+     */
+    ociS3Service.closeContext()
+  }
+
+}


### PR DESCRIPTION
Oracle Cloud Infrastructure has S3 compliant object storage. The current version of `cloud-storage-sdk` doesn't have implementation for OCI.

This PR has the changes to support OCI. The configuration to enable OCI is below:

```yaml
# OCI Configuration
oci_storage_container=""
oci_storage_key=""
oci_storage_secret=""
oci_region=""
# sample endpoint url: https://<bucket-namespace>.compat.objectstorage.<region>.oraclecloud.com
oci_storage_endpoint=""

```
Sunbird-Ed Discussion: [Sunbird-Ed#349](https://github.com/Sunbird-Ed/Community/discussions/349)
