### PR TITLE
fix: Decoding blob url since azure sdk percent-encodes the blob name

### DIFF
--- a/cloud-storage-sdk-api/pom.xml
+++ b/cloud-storage-sdk-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-api</artifactId>

--- a/cloud-storage-sdk-api/src/main/java/org/sunbird/cloud/storage/AbstractStorageService.java
+++ b/cloud-storage-sdk-api/src/main/java/org/sunbird/cloud/storage/AbstractStorageService.java
@@ -106,7 +106,8 @@ public abstract class AbstractStorageService implements IStorageService {
                 for (File f : files) {
                     String relativePath = f.getAbsolutePath()
                             .substring((dir.getAbsolutePath() + File.separator).length());
-                    String key = objectKey + "/" + relativePath;
+                    String prefix = objectKey.endsWith("/") ? objectKey : objectKey + "/";
+                    String key = prefix + relativePath;
                     urls.add(upload(container, f.getAbsolutePath(), key, false, attempt, maxAttempts, ttl));
                 }
                 return String.join(",", urls);
@@ -153,7 +154,8 @@ public abstract class AbstractStorageService implements IStorageService {
             for (File f : files) {
                 String relativePath = f.getAbsolutePath()
                         .substring((dir.getAbsolutePath() + File.separator).length());
-                String key = objectKey + "/" + relativePath;
+                String prefix = objectKey.endsWith("/") ? objectKey : objectKey + "/";
+                String key = prefix + relativePath;
                 futures.add(CompletableFuture.supplyAsync(() ->
                         upload(container, f.getAbsolutePath(), key, false, attempt,
                                 retryCount != null ? retryCount : 0, ttl)));

--- a/cloud-storage-sdk-api/src/test/java/org/sunbird/cloud/storage/AbstractStorageServiceTest.java
+++ b/cloud-storage-sdk-api/src/test/java/org/sunbird/cloud/storage/AbstractStorageServiceTest.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -58,6 +59,71 @@ class AbstractStorageServiceTest {
         assertTrue(result.contains("prefix/data/b.txt"));
         assertTrue(service.exists("bucket", "prefix/data/a.txt"));
         assertTrue(service.exists("bucket", "prefix/data/b.txt"));
+    }
+
+    @Test
+    void upload_directory_withTrailingSlash_noDoubleSlash() throws IOException {
+        Path dir = tempDir.resolve("data-slash");
+        Files.createDirectory(dir);
+        Files.writeString(dir.resolve("a.txt"), "aaa");
+        Files.writeString(dir.resolve("b.txt"), "bbb");
+
+        // objectKey already ends with '/' — must not produce "prefix/data//a.txt"
+        String result = service.upload("bucket", dir.toString(), "prefix/data/", true, 1, 0, null);
+
+        assertTrue(result.contains("prefix/data/a.txt"), "Expected prefix/data/a.txt, got: " + result);
+        assertTrue(result.contains("prefix/data/b.txt"), "Expected prefix/data/b.txt, got: " + result);
+        assertFalse(result.contains("//"), "Keys must not contain double slashes: " + result);
+        assertTrue(service.exists("bucket", "prefix/data/a.txt"));
+        assertTrue(service.exists("bucket", "prefix/data/b.txt"));
+    }
+
+    @Test
+    void upload_directory_withoutTrailingSlash_addsSingleSlash() throws IOException {
+        Path dir = tempDir.resolve("data-noslash");
+        Files.createDirectory(dir);
+        Files.writeString(dir.resolve("c.txt"), "ccc");
+
+        // objectKey has no trailing '/' — must add exactly one
+        String result = service.upload("bucket", dir.toString(), "prefix/data", true, 1, 0, null);
+
+        assertTrue(result.contains("prefix/data/c.txt"), "Expected prefix/data/c.txt, got: " + result);
+        assertFalse(result.contains("//"), "Keys must not contain double slashes: " + result);
+        assertTrue(service.exists("bucket", "prefix/data/c.txt"));
+    }
+
+    @Test
+    void uploadFolder_withTrailingSlash_noDoubleSlash() throws ExecutionException, InterruptedException {
+        Path dir = tempDir.resolve("async-slash");
+        Files.createDirectory(dir);
+        Files.writeString(dir.resolve("x.txt"), "xxx");
+        Files.writeString(dir.resolve("y.txt"), "yyy");
+
+        // async uploadFolder — same prefix logic at line 157-158
+        List<String> urls = service.uploadFolder("bucket", dir.toString(), "async/data/")
+                .get();
+
+        assertTrue(urls.stream().anyMatch(u -> u.contains("async/data/x.txt")),
+                "Expected async/data/x.txt in: " + urls);
+        assertTrue(urls.stream().anyMatch(u -> u.contains("async/data/y.txt")),
+                "Expected async/data/y.txt in: " + urls);
+        urls.forEach(u -> assertFalse(u.contains("//"),
+                "URL must not contain double slashes: " + u));
+    }
+
+    @Test
+    void uploadFolder_withoutTrailingSlash_addsSingleSlash() throws ExecutionException, InterruptedException {
+        Path dir = tempDir.resolve("async-noslash");
+        Files.createDirectory(dir);
+        Files.writeString(dir.resolve("z.txt"), "zzz");
+
+        List<String> urls = service.uploadFolder("bucket", dir.toString(), "async/data")
+                .get();
+
+        assertTrue(urls.stream().anyMatch(u -> u.contains("async/data/z.txt")),
+                "Expected async/data/z.txt in: " + urls);
+        urls.forEach(u -> assertFalse(u.contains("//"),
+                "URL must not contain double slashes: " + u));
     }
 
     @Test

--- a/cloud-storage-sdk-aws/pom.xml
+++ b/cloud-storage-sdk-aws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-aws</artifactId>

--- a/cloud-storage-sdk-azure/pom.xml
+++ b/cloud-storage-sdk-azure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-azure</artifactId>

--- a/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
+++ b/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
@@ -12,6 +12,8 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobListDetails;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import com.azure.storage.blob.options.BlobUploadFromFileOptions;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
@@ -130,7 +132,7 @@ public class AzureStorageService extends AbstractStorageService {
             BlobClient blobClient = getBlobClient(container, objectKey);
             String contentType = tika.detect(file);
             blobClient.uploadFromFileWithResponse(
-                    new com.azure.storage.blob.options.BlobUploadFromFileOptions(file.getAbsolutePath())
+                    new BlobUploadFromFileOptions(file.getAbsolutePath())
                             .setHeaders(new BlobHttpHeaders().setContentType(contentType)),
                     null, null);
             return decodeBlobUrl(blobClient.getBlobUrl());
@@ -146,8 +148,7 @@ public class AzureStorageService extends AbstractStorageService {
             BlobClient blobClient = getBlobClient(container, objectKey);
             String contentType = tika.detect(new ByteArrayInputStream(content), objectKey);
             blobClient.uploadWithResponse(
-                    new com.azure.storage.blob.options.BlobParallelUploadOptions(
-                            new ByteArrayInputStream(content), content.length)
+                    new BlobParallelUploadOptions(new ByteArrayInputStream(content), content.length)
                             .setHeaders(new BlobHttpHeaders().setContentType(contentType)),
                     null, null);
             return decodeBlobUrl(blobClient.getBlobUrl());

--- a/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
+++ b/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
@@ -129,9 +129,10 @@ public class AzureStorageService extends AbstractStorageService {
         try {
             BlobClient blobClient = getBlobClient(container, objectKey);
             String contentType = tika.detect(file);
-            blobClient.uploadFromFile(file.getAbsolutePath(), null,
-                    new BlobHttpHeaders().setContentType(contentType),
-                    null, null, null, null);
+            blobClient.uploadFromFileWithResponse(
+                    new com.azure.storage.blob.options.BlobUploadFromFileOptions(file.getAbsolutePath())
+                            .setHeaders(new BlobHttpHeaders().setContentType(contentType)),
+                    null, null);
             return decodeBlobUrl(blobClient.getBlobUrl());
         } catch (Exception e) {
             throw new StorageServiceException(

--- a/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
+++ b/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
@@ -7,6 +7,7 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobListDetails;
 import com.azure.storage.blob.models.BlobProperties;
@@ -94,6 +95,21 @@ public class AzureStorageService extends AbstractStorageService {
         return getContainerClient(container).getBlobClient(objectKey);
     }
 
+    /**
+     * The Azure SDK's getBlobUrl() encodes '/' in blob names as '%2F'.
+     * This replaces only %2F with '/', leaving all other percent-encoded characters
+     */
+    private String decodeBlobUrl(String url) {
+        try {
+            java.net.URI uri = new java.net.URI(url);
+            String path = uri.getRawPath().replace("%2F", "/").replace("%2f", "/");
+            String result = uri.getScheme() + "://" + uri.getRawAuthority() + path;
+            return uri.getRawQuery() != null ? result + "?" + uri.getRawQuery() : result;
+        } catch (java.net.URISyntaxException e) {
+            return url;
+        }
+    }
+
     @Override
     protected void ensureContainerExists(String container) {
         try {
@@ -113,10 +129,10 @@ public class AzureStorageService extends AbstractStorageService {
         try {
             BlobClient blobClient = getBlobClient(container, objectKey);
             String contentType = tika.detect(file);
-            blobClient.uploadFromFile(file.getAbsolutePath(), true);
-            blobClient.setHttpHeaders(new com.azure.storage.blob.models.BlobHttpHeaders()
-                    .setContentType(contentType));
-            return blobClient.getBlobUrl();
+            blobClient.uploadFromFile(file.getAbsolutePath(), null,
+                    new BlobHttpHeaders().setContentType(contentType),
+                    null, null, null, null);
+            return decodeBlobUrl(blobClient.getBlobUrl());
         } catch (Exception e) {
             throw new StorageServiceException(
                     "Failed to put object from file: " + objectKey + " - " + e.getMessage(), e);
@@ -127,8 +143,13 @@ public class AzureStorageService extends AbstractStorageService {
     protected String putObject(String container, String objectKey, byte[] content) {
         try {
             BlobClient blobClient = getBlobClient(container, objectKey);
-            blobClient.upload(new ByteArrayInputStream(content), content.length, true);
-            return blobClient.getBlobUrl();
+            String contentType = tika.detect(new ByteArrayInputStream(content), objectKey);
+            blobClient.uploadWithResponse(
+                    new com.azure.storage.blob.options.BlobParallelUploadOptions(
+                            new ByteArrayInputStream(content), content.length)
+                            .setHeaders(new BlobHttpHeaders().setContentType(contentType)),
+                    null, null);
+            return decodeBlobUrl(blobClient.getBlobUrl());
         } catch (Exception e) {
             throw new StorageServiceException(
                     "Failed to put object from bytes: " + objectKey + " - " + e.getMessage(), e);
@@ -148,7 +169,7 @@ public class AzureStorageService extends AbstractStorageService {
 
     @Override
     protected String getObjectUri(String container, String objectKey) {
-        return getBlobClient(container, objectKey).getBlobUrl();
+        return decodeBlobUrl(getBlobClient(container, objectKey).getBlobUrl());
     }
 
     @Override
@@ -161,7 +182,8 @@ public class AzureStorageService extends AbstractStorageService {
             if (props.getMetadata() != null) {
                 metadata.putAll(props.getMetadata());
             }
-            metadata.put("uri", blobClient.getBlobUrl());
+            String blobUrl = decodeBlobUrl(blobClient.getBlobUrl());
+            metadata.put("uri", blobUrl);
             metadata.put("Content-Type", props.getContentType());
             metadata.put("ETag", props.getETag());
 
@@ -170,7 +192,7 @@ public class AzureStorageService extends AbstractStorageService {
                     : null;
 
             return new BlobDetail(objectKey, props.getBlobSize(), lastModified,
-                    metadata, blobClient.getBlobUrl());
+                    metadata, blobUrl);
         } catch (Exception e) {
             throw new StorageServiceException(
                     "Failed to get object detail: " + objectKey + " - " + e.getMessage(), e);
@@ -231,14 +253,14 @@ public class AzureStorageService extends AbstractStorageService {
             BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(
                     OffsetDateTime.now().plusSeconds(ttlSeconds), permission);
 
+            String baseUrl = decodeBlobUrl(blobClient.getBlobUrl());
             if (useSharedKey) {
-                return blobClient.getBlobUrl() + "?" + blobClient.generateSas(values);
+                return baseUrl + "?" + blobClient.generateSas(values);
             } else {
                 var delegationKey = blobServiceClient.getUserDelegationKey(
                         OffsetDateTime.now().minusMinutes(5),
                         OffsetDateTime.now().plusSeconds(ttlSeconds));
-                return blobClient.getBlobUrl() + "?" +
-                        blobClient.generateUserDelegationSas(values, delegationKey);
+                return baseUrl + "?" + blobClient.generateUserDelegationSas(values, delegationKey);
             }
         } catch (Exception e) {
             throw new StorageServiceException(
@@ -261,14 +283,14 @@ public class AzureStorageService extends AbstractStorageService {
                 values.setContentType(contentType);
             }
 
+            String baseUrl = decodeBlobUrl(blobClient.getBlobUrl());
             if (useSharedKey) {
-                return blobClient.getBlobUrl() + "?" + blobClient.generateSas(values);
+                return baseUrl + "?" + blobClient.generateSas(values);
             } else {
                 var delegationKey = blobServiceClient.getUserDelegationKey(
                         OffsetDateTime.now().minusMinutes(5),
                         OffsetDateTime.now().plusSeconds(ttlSeconds));
-                return blobClient.getBlobUrl() + "?" +
-                        blobClient.generateUserDelegationSas(values, delegationKey);
+                return baseUrl + "?" + blobClient.generateUserDelegationSas(values, delegationKey);
             }
         } catch (Exception e) {
             throw new StorageServiceException(

--- a/cloud-storage-sdk-gcp/pom.xml
+++ b/cloud-storage-sdk-gcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-gcp</artifactId>

--- a/cloud-storage-sdk-oci/pom.xml
+++ b/cloud-storage-sdk-oci/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-oci</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sunbird</groupId>
     <artifactId>cloud-storage-sdk-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
     <name>Cloud Storage SDK Parent</name>
     <description>Multi-module cloud storage SDK providing CSP-specific implementations using official cloud SDKs.</description>


### PR DESCRIPTION
This PR includes these key changes: 
- Updated Code to handle if objectKey is already ending with "/"
- Decoding blob url since azure sdk's BlobClient.getBlobUrl() percent-encodes the blob name