### PR TITLE
fix: Exclude azure-core-http-netty and align okhttp to azure-core 1.45.0

### DIFF
--- a/cloud-storage-sdk-api/pom.xml
+++ b/cloud-storage-sdk-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-api</artifactId>

--- a/cloud-storage-sdk-aws/pom.xml
+++ b/cloud-storage-sdk-aws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-aws</artifactId>

--- a/cloud-storage-sdk-azure/pom.xml
+++ b/cloud-storage-sdk-azure/pom.xml
@@ -21,10 +21,22 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -45,5 +57,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>    </dependencies>
+        </dependency>
+    </dependencies>
 </project>

--- a/cloud-storage-sdk-azure/pom.xml
+++ b/cloud-storage-sdk-azure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-azure</artifactId>

--- a/cloud-storage-sdk-gcp/pom.xml
+++ b/cloud-storage-sdk-gcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-gcp</artifactId>

--- a/cloud-storage-sdk-oci/pom.xml
+++ b/cloud-storage-sdk-oci/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-oci</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <aws.sdk.version>2.25.0</aws.sdk.version>
         <azure.storage.blob.version>12.25.0</azure.storage.blob.version>
         <azure.identity.version>1.11.0</azure.identity.version>
-        <azure.core.http.okhttp.version>1.11.20</azure.core.http.okhttp.version>
+        <azure.core.http.okhttp.version>1.11.0</azure.core.http.okhttp.version>
         <gcp.storage.version>2.30.0</gcp.storage.version>
         <oci.sdk.version>3.30.0</oci.sdk.version>
         <tika.version>2.9.0</tika.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sunbird</groupId>
     <artifactId>cloud-storage-sdk-parent</artifactId>
-    <version>2.0.2-beta</version>
+    <version>2.0.2</version>
     <packaging>pom</packaging>
     <name>Cloud Storage SDK Parent</name>
     <description>Multi-module cloud storage SDK providing CSP-specific implementations using official cloud SDKs.</description>


### PR DESCRIPTION
### Summary:
Exclude the transitive azure-core-http-netty from azure-storage-blob and
azure-identity so the SDK ships only the OkHttp HTTP transport. This removes
reactor-netty entirely from the SDK classpath, eliminating any future netty
validation regressions (e.g. the 4.1.129 bitmask bug where 1L << c wraps
modulo 64 and rejects uppercase ASCII chars J/M/backtick as LF/CR/SPACE).

Downgrade azure-core-http-okhttp 1.11.20 -> 1.11.0 to match the azure-core
1.45.0 bundled by downstream consumers (asset-enrichment fat jar in
knowledge-platform-jobs). 1.11.20 calls BinaryData.writeTo(WritableByteChannel)
which was added in azure-core 1.49.0 and triggers NoSuchMethodError at
runtime.