### PR TITLE
fix(azure): switch to OkHttp transport to avoid Netty %2F/uppercase request-line rejection

### DIFF
--- a/cloud-storage-sdk-api/pom.xml
+++ b/cloud-storage-sdk-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-beta</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-api</artifactId>

--- a/cloud-storage-sdk-api/pom.xml
+++ b/cloud-storage-sdk-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-api</artifactId>

--- a/cloud-storage-sdk-aws/pom.xml
+++ b/cloud-storage-sdk-aws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-beta</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-aws</artifactId>

--- a/cloud-storage-sdk-aws/pom.xml
+++ b/cloud-storage-sdk-aws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-aws</artifactId>

--- a/cloud-storage-sdk-azure/pom.xml
+++ b/cloud-storage-sdk-azure/pom.xml
@@ -21,10 +21,22 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -45,5 +57,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>    </dependencies>
+        </dependency>
+    </dependencies>
 </project>

--- a/cloud-storage-sdk-azure/pom.xml
+++ b/cloud-storage-sdk-azure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-beta</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-azure</artifactId>
@@ -27,6 +27,10 @@
             <artifactId>azure-identity</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-okhttp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>cloud-storage-sdk-api</artifactId>
             <classifier>tests</classifier>
@@ -41,6 +45,5 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>
-    </dependencies>
+        </dependency>    </dependencies>
 </project>

--- a/cloud-storage-sdk-azure/pom.xml
+++ b/cloud-storage-sdk-azure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-azure</artifactId>

--- a/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
+++ b/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
@@ -50,7 +50,14 @@ public class AzureStorageService extends AbstractStorageService {
         String accountName = config.getStorageKey();
         String endpoint = "https://" + accountName + ".blob.core.windows.net";
 
-        BlobServiceClientBuilder builder = new BlobServiceClientBuilder().endpoint(endpoint);
+        // Use OkHttp transport instead of default reactor-netty.
+        // Reason: reactor-netty's HttpUtil.validateRequestLineTokens rejects '%2F' in
+        // DefaultFullHttpRequest. Azure SDK percent-encodes '/' in blob names as '%2F'
+        // in the request line, which breaks single-shot REST ops (e.g. copyFromUrl) on
+        // nested blob paths. OkHttp transport does not enforce that validation.
+        BlobServiceClientBuilder builder = new BlobServiceClientBuilder()
+                .endpoint(endpoint)
+                .httpClient(new com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder().build());
 
         switch (config.getAuthType()) {
             case ACCESS_KEY:

--- a/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
+++ b/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
@@ -17,6 +17,7 @@ import com.azure.storage.blob.options.BlobUploadFromFileOptions;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sunbird.cloud.storage.AbstractStorageService;
@@ -50,14 +51,10 @@ public class AzureStorageService extends AbstractStorageService {
         String accountName = config.getStorageKey();
         String endpoint = "https://" + accountName + ".blob.core.windows.net";
 
-        // Use OkHttp transport instead of default reactor-netty.
-        // Reason: reactor-netty's HttpUtil.validateRequestLineTokens rejects '%2F' in
-        // DefaultFullHttpRequest. Azure SDK percent-encodes '/' in blob names as '%2F'
-        // in the request line, which breaks single-shot REST ops (e.g. copyFromUrl) on
-        // nested blob paths. OkHttp transport does not enforce that validation.
+        // OkHttp avoids Netty's request-line bitmask bug that rejects uppercase chars in percent-encoded blob names.
         BlobServiceClientBuilder builder = new BlobServiceClientBuilder()
                 .endpoint(endpoint)
-                .httpClient(new com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder().build());
+                .httpClient(new OkHttpAsyncHttpClientBuilder().build());
 
         switch (config.getAuthType()) {
             case ACCESS_KEY:

--- a/cloud-storage-sdk-gcp/pom.xml
+++ b/cloud-storage-sdk-gcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-beta</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-gcp</artifactId>

--- a/cloud-storage-sdk-gcp/pom.xml
+++ b/cloud-storage-sdk-gcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-gcp</artifactId>

--- a/cloud-storage-sdk-oci/pom.xml
+++ b/cloud-storage-sdk-oci/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.2-beta</version>
+        <version>2.0.2</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-oci</artifactId>

--- a/cloud-storage-sdk-oci/pom.xml
+++ b/cloud-storage-sdk-oci/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sunbird</groupId>
         <artifactId>cloud-storage-sdk-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-beta</version>
     </parent>
 
     <artifactId>cloud-storage-sdk-oci</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <aws.sdk.version>2.25.0</aws.sdk.version>
         <azure.storage.blob.version>12.25.0</azure.storage.blob.version>
         <azure.identity.version>1.11.0</azure.identity.version>
-        <azure.core.http.okhttp.version>1.11.20</azure.core.http.okhttp.version>
+        <azure.core.http.okhttp.version>1.11.0</azure.core.http.okhttp.version>
         <gcp.storage.version>2.30.0</gcp.storage.version>
         <oci.sdk.version>3.30.0</oci.sdk.version>
         <tika.version>2.9.0</tika.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sunbird</groupId>
     <artifactId>cloud-storage-sdk-parent</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-beta</version>
     <packaging>pom</packaging>
     <name>Cloud Storage SDK Parent</name>
     <description>Multi-module cloud storage SDK providing CSP-specific implementations using official cloud SDKs.</description>
@@ -20,6 +20,7 @@
         <aws.sdk.version>2.25.0</aws.sdk.version>
         <azure.storage.blob.version>12.25.0</azure.storage.blob.version>
         <azure.identity.version>1.11.0</azure.identity.version>
+        <azure.core.http.okhttp.version>1.11.20</azure.core.http.okhttp.version>
         <gcp.storage.version>2.30.0</gcp.storage.version>
         <oci.sdk.version>3.30.0</oci.sdk.version>
         <tika.version>2.9.0</tika.version>
@@ -125,6 +126,11 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
                 <version>${azure.identity.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-core-http-okhttp</artifactId>
+                <version>${azure.core.http.okhttp.version}</version>
             </dependency>
 
             <!-- GCP -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <aws.sdk.version>2.25.0</aws.sdk.version>
         <azure.storage.blob.version>12.25.0</azure.storage.blob.version>
         <azure.identity.version>1.11.0</azure.identity.version>
+        <!-- Pinned to 1.11.0: >=1.11.20 requires azure-core >=1.49.0, but knowledge-platform-jobs bundles azure-core 1.45.0 -->
         <azure.core.http.okhttp.version>1.11.0</azure.core.http.okhttp.version>
         <gcp.storage.version>2.30.0</gcp.storage.version>
         <oci.sdk.version>3.30.0</oci.sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sunbird</groupId>
     <artifactId>cloud-storage-sdk-parent</artifactId>
-    <version>2.0.2-beta</version>
+    <version>2.0.2</version>
     <packaging>pom</packaging>
     <name>Cloud Storage SDK Parent</name>
     <description>Multi-module cloud storage SDK providing CSP-specific implementations using official cloud SDKs.</description>


### PR DESCRIPTION
## Summary

Azure SDK percent-encodes `/` in blob names as `%2F` in the HTTP request line, and Netty 4.1.108–4.1.130's `HttpUtil.isEncodingSafeStartLineToken` uses a buggy bitmask check (`1L << c`) that wraps modulo 64 and incorrectly rejects uppercase ASCII characters `J` (74), `M` (77), and backtick (96) as if they were LF / CR / SPACE. The combined effect breaks `BlobClient.copyFromUrl` (no-body PUT) for any blob whose name contains those characters — e.g. `SCORM_API.js` — with `IllegalArgumentException: The URI contain illegal characters: ...`.

This PR switches the Azure `BlobServiceClient` from the default reactor-netty HTTP transport to OkHttp, which does not perform that validation. It also excludes `azure-core-http-netty` from the SDK classpath so consumers do not accidentally pick reactor-netty back up.

## Root cause

| Layer | Behaviour |
|---|---|
| Azure SDK Java | `BlobClient.getBlobUrl()` and the request builder URL-encode `/` in blob names as `%2F` in the request line |
| Reactor-netty (4.1.108–4.1.130) | `isEncodingSafeStartLineToken` builds a bitmask with `1L << c`. Java `<<` on `long` wraps modulo 64, so `'M' = 77` maps to bit `13` (CR), `'J' = 74` maps to bit `10` (LF), `` '`' = 96 `` maps to bit `32` (SPACE). All three trigger rejection. |
| cloud-storage-sdk-azure (before this PR) | `destBlobClient.copyFromUrl(...)` → no-body `DefaultFullHttpRequest` → Netty validates → `IllegalArgumentException: The URI contain illegal characters` |

Production stack trace excerpt:
```
Caused by: java.lang.IllegalArgumentException: The URI contain illegal characters:
  /<container>/content%2Fscorm%2Fdo_xxx-version%2FSCORM_API.js
    at io.netty.handler.codec.http.HttpUtil.validateRequestLineTokens(HttpUtil.java:90)
    at io.netty.handler.codec.http.DefaultHttpRequest.<init>(DefaultHttpRequest.java:95)
    at reactor.netty.http.client.HttpClientOperations.newFullBodyMessage(...)
    at com.azure.storage.blob.specialized.BlobClientBase.copyFromUrl(BlobClientBase.java:704)
    at org.sunbird.cloud.storage.service.azure.AzureStorageService.copyObject(AzureStorageService.java:242)
```

The `%2F` portion is a red herring — it is valid percent-encoding. The actual char that trips the bitmask is the uppercase `M` in `SCORM_API.js`. Lowercase `scorm_api.js` (same content) passes because lowercase `m` (109) maps to bit `45`, which is not in the forbidden mask. Streaming/chunked uploads also avoid the issue because they do not use `DefaultFullHttpRequest`.

## Changes

- Parent `pom.xml`: add `azure.core.http.okhttp.version = 1.11.0` property and `azure-core-http-okhttp` `dependencyManagement` entry. Version `1.11.0` is intentional — it is compatible with `azure-core 1.45.0` bundled by downstream consumers (e.g. `asset-enrichment` fat jar in `knowledge-platform-jobs`). Newer `1.11.20` calls `BinaryData.writeTo(WritableByteChannel)` (added in azure-core 1.49.0) and throws `NoSuchMethodError` at runtime.
- `cloud-storage-sdk-azure/pom.xml`:
  - Add `azure-core-http-okhttp` dependency.
  - Exclude transitive `azure-core-http-netty` from `azure-storage-blob` and `azure-identity` so reactor-netty is not on the SDK classpath at all.
- `cloud-storage-sdk-azure/.../AzureStorageService.java`: wire the OkHttp client on the `BlobServiceClientBuilder`:
  ```java
  new BlobServiceClientBuilder()
      .endpoint(endpoint)
      .httpClient(new OkHttpAsyncHttpClientBuilder().build())
  ```
  `copyObject` itself is unchanged.
- Bump SDK version `2.0.1` → `2.0.2` across parent + all modules.

## Verification

Integration test against dev Azure account using the exact failing SCORM snapshot (`content/scorm/do_2145843106720808961102-snapshot/`) and `SCORM_API.js` filename:

| Run | HTTP transport | Netty on classpath | Filename | Result |
|---|---|---|---|---|
| 1 | reactor-netty (default) | 4.1.131 (no bitmask bug) | `SCORM_API.js` | PASS — netty fixed in 4.1.131, repro requires older |
| 2 | reactor-netty (default) | 4.1.129 (bitmask bug) | `SCORM_API.js` | **FAIL** — `URI contain illegal characters: ...%2F...SCORM_API.js` (production bug reproduced) |
| 3 | reactor-netty (default) | 4.1.129 (bitmask bug) | `scorm_api.js` (lowercase) | PASS — confirms the bug is uppercase-specific |
| 4 | **OkHttp (this PR)** | none (excluded) | `SCORM_API.js` | **PASS** |
| 5 | **OkHttp (this PR)** | 4.1.131 + reactor-netty added in test scope (simulates Flink user-jar with netty bundled) | `SCORM_API.js` | **PASS** — explicit `.httpClient(okhttp)` overrides default even when reactor-netty is present |

All existing Azure integration tests (upload, list, download, signed URLs, copy, delete, search, getPaths) continue to pass on OkHttp.

## Why OkHttp vs. other workarounds

| Option | Verdict |
|---|---|
| Decode dest URL + rebuild `BlobClient` via `BlobClientBuilder.endpoint(decodedUrl)` | Does NOT work — SDK parses, splits container/blob, re-encodes blob path at request time |
| Bump netty to 4.1.131+ in consumers only | Fragile — relies on every consumer aligning; some bundle older netty in fat jars (asset-enrichment) |
| Downgrade reactor-netty < 4.1.108 | Reopens CVE-2024-29025 and related fixes; not acceptable |
| Replace Azure SDK calls with raw HTTP PUT + manual auth signing | High complexity, separate path per auth type |
| **Swap HTTP transport to OkHttp + exclude azure-core-http-netty** (this PR) | Single wiring change, isolates fix to SDK module, robust across consumer netty versions, removes netty from SDK classpath entirely |

## Test plan

- [x] All Azure integration tests pass (`uploadAndList`, `uploadFolder`, `putAndGetData`, `downloadFile`, `getSignedReadUrl`, `getSignedWriteUrl`, `copyObject`, `deleteObject`, `searchObjectsByDate`, `getPaths`, `getObjectMetadata`, `getObjectWithPayload`, etc.)
- [x] Bug reproduced under reactor-netty + Netty 4.1.129 with uppercase filename
- [x] Fix verified — OkHttp transport copies `SCORM_API.js` (uppercase M) successfully
- [x] Fix verified with reactor-netty also on classpath (simulates Flink user-jar)
- [ ] Smoke test downstream `knowledge-platform-jobs` SCORM publish end-to-end on dev with `cloud-store-sdk = 2.0.2`
- [ ] Smoke test ECML and HTML publish on dev — no regression