### PR TITLE
fix: Use OkHttp transport for Azure SDK

### DIFF
--- a/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
+++ b/cloud-storage-sdk-azure/src/main/java/org/sunbird/cloud/storage/service/azure/AzureStorageService.java
@@ -17,6 +17,7 @@ import com.azure.storage.blob.options.BlobUploadFromFileOptions;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sunbird.cloud.storage.AbstractStorageService;
@@ -50,14 +51,10 @@ public class AzureStorageService extends AbstractStorageService {
         String accountName = config.getStorageKey();
         String endpoint = "https://" + accountName + ".blob.core.windows.net";
 
-        // Use OkHttp transport instead of default reactor-netty.
-        // Reason: reactor-netty's HttpUtil.validateRequestLineTokens rejects '%2F' in
-        // DefaultFullHttpRequest. Azure SDK percent-encodes '/' in blob names as '%2F'
-        // in the request line, which breaks single-shot REST ops (e.g. copyFromUrl) on
-        // nested blob paths. OkHttp transport does not enforce that validation.
+        // OkHttp avoids Netty's request-line bitmask bug that rejects uppercase chars in percent-encoded blob names.
         BlobServiceClientBuilder builder = new BlobServiceClientBuilder()
                 .endpoint(endpoint)
-                .httpClient(new com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder().build());
+                .httpClient(new OkHttpAsyncHttpClientBuilder().build());
 
         switch (config.getAuthType()) {
             case ACCESS_KEY:

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <aws.sdk.version>2.25.0</aws.sdk.version>
         <azure.storage.blob.version>12.25.0</azure.storage.blob.version>
         <azure.identity.version>1.11.0</azure.identity.version>
+        <!-- Pinned to 1.11.0: >=1.11.20 requires azure-core >=1.49.0, but knowledge-platform-jobs bundles azure-core 1.45.0 -->
         <azure.core.http.okhttp.version>1.11.0</azure.core.http.okhttp.version>
         <gcp.storage.version>2.30.0</gcp.storage.version>
         <oci.sdk.version>3.30.0</oci.sdk.version>


### PR DESCRIPTION
### Summary:
Switch AzureStorageService to use the azure-core OkHttp async HTTP client (OkHttpAsyncHttpClientBuilder) to avoid reactor-netty's request-line validation bug that can reject percent-encoded/uppercase characters in blob names. Add and pin azure.core.http.okhttp.version to 1.11.0 in pom.xml with a comment noting newer okhttp bindings require azure-core >=1.49.0 while the build currently bundles azure-core 1.45.0.